### PR TITLE
Upgrade dependency org.xerial.snappy

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
         <dependency>
             <groupId>org.xerial.snappy</groupId>
             <artifactId>snappy-java</artifactId>
-            <version>1.1.2.1</version>
+            <version>1.1.8.4</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
Upgrading the dependency snappy-java's version to support M1 chip.

Related issue: https://github.com/xerial/snappy-java/issues/276