### PR TITLE
fix: 发送策略都会启动线程

### DIFF
--- a/gio-sdk-java-demo/pom.xml
+++ b/gio-sdk-java-demo/pom.xml
@@ -36,6 +36,11 @@
         </dependency>
     </dependencies>
 
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <jdk.version>1.6</jdk.version>
+    </properties>
+
     <build>
         <plugins>
             <plugin>
@@ -67,6 +72,16 @@
                         </configuration>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.3</version>
+                <configuration>
+                    <source>${jdk.version}</source>
+                    <target>${jdk.version}</target>
+                    <encoding>${project.build.sourceEncoding}</encoding>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/gio-sdk-java-demo/src/main/java/io/growing/sdk/java/demo/Demo.java
+++ b/gio-sdk-java-demo/src/main/java/io/growing/sdk/java/demo/Demo.java
@@ -6,11 +6,9 @@ import io.growing.sdk.java.dto.GioCdpEventMessage;
 import io.growing.sdk.java.dto.GioCdpItemMessage;
 import io.growing.sdk.java.dto.GioCdpUserMessage;
 import io.growing.sdk.java.exception.GIOSendBeRejectedException;
-import io.growing.sdk.java.utils.ConfigUtils;
 
 import java.util.HashMap;
 import java.util.Map;
-import java.util.concurrent.TimeUnit;
 
 /**
  * @author : tong.wang

--- a/src/main/java/io/growing/sdk/java/store/StoreStrategyClient.java
+++ b/src/main/java/io/growing/sdk/java/store/StoreStrategyClient.java
@@ -14,17 +14,20 @@ public class StoreStrategyClient {
 
     public static final StoreStrategyEnum CURRENT_STRATEGY = StoreStrategyEnum.getByValue(ConfigUtils.getStringValue("msg.store.strategy", "default"));
 
-    private static class StoreInstance {
+    private static class DefaultStoreInstance {
         static StoreStrategy defaultStoreStrategy = new DefaultStoreStrategy();
+    }
+
+    private static class AbortPolicyStoreInstance {
         static StoreStrategy abortPolicyStoreStrategy = new AbortPolicyStoreStrategy();
     }
 
     public static StoreStrategy getStoreInstance(StoreStrategyEnum strategy) {
         StoreStrategy storeStrategy;
         if (strategy == StoreStrategyEnum.ABORT_POLICY) {
-            storeStrategy = StoreInstance.abortPolicyStoreStrategy;
+            storeStrategy = AbortPolicyStoreInstance.abortPolicyStoreStrategy;
         } else {
-            storeStrategy = StoreInstance.defaultStoreStrategy;
+            storeStrategy = DefaultStoreInstance.defaultStoreStrategy;
         }
         storeStrategy.shutdownAwait();
         return storeStrategy;


### PR DESCRIPTION
demo中增加jdk版本设置, maven默认使用jdk1.5, 会抛出异常Error : java 不支持发行版本5的问题

修正策略不管是default还是abort都会启动各自线程消费事件