### PR TITLE
fix: demo不支持发行版本5

### DIFF
--- a/gio-sdk-java-demo/pom.xml
+++ b/gio-sdk-java-demo/pom.xml
@@ -12,6 +12,11 @@
     <name>growingio-java-sdk-demo</name>
     <url>http://www.growingio.com</url>
 
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <jdk.version>1.6</jdk.version>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>io.growing.sdk.java</groupId>
@@ -33,6 +38,16 @@
 
     <build>
         <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.3</version>
+                <configuration>
+                    <source>${jdk.version}</source>
+                    <target>${jdk.version}</target>
+                    <encoding>${project.build.sourceEncoding}</encoding>
+                </configuration>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>


### PR DESCRIPTION
demo中增加jdk版本设置, maven默认使用jdk1.5, 会抛出异常Error : java 不支持发行版本5的问题