### PR TITLE
fix: 修正多线程异常，增加shutdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,8 +69,8 @@ project.send(eventMessage);
 ```
 
 ## 配置文件信息
-
-gio.properties
+配置在资源目录
+resources/gio.properties
 
 ```properties
 #项目采集端地址, https://api.growingio.com 需要填写完整的url地址, 如不清楚请联系您的专属项目经理
@@ -90,18 +90,18 @@ logger.implemention=io.growing.sdk.java.logger.GioLoggerImpl
 #运行模式，test:仅输出消息体，不发送消息，production: 发送消息
 run.mode=test
 # 设置代理, 如果不设置，默认为不使用代理
-proxy.host=127.0.0.1
-proxy.port=3128
+#proxy.host=127.0.0.1
+#proxy.port=3128
 # 设置代理认证用户密码, 如果不设置，默认为不使用用户验证 [认证加密方式为 Basic base64]
-proxy.user=demo
-proxy.password=demo
+#proxy.user=demo
+#proxy.password=demo
 #http 连接超时时间,默认2秒
 #connection.timeout=2000
 #http 连接读取时间,默认2秒
 #read.timeout=2000
 # 带拒绝策略的发送策略，默认不采用，此策略在队列快满时打印出debug日志，并且会使用新的线程（个数同send.msg.thread）加速消费队列元素
 # 但可能仍然消费速度不够，导致抛出GIOSendBeRejectedException异常，为了保险起见，使用者应当捕获该异常。
-# 并且此策略新增了shutdownAwait方法关联了队列状态和JVM关闭钩子，此举旨在防止主线程关闭时，内存队列未消费的元素丢失。
+# 策略新增了registerShutdownHook方法关联了队列状态和JVM关闭钩子，此举旨在防止主线程关闭时，内存队列未消费的元素丢失。
 # msg.store.strategy=abortPolicy
 # 队列负载率，当为0.5时，表明，队列中元素达到一半时，会出现debug日志，并会使用新线程加速消费队列。队列负载降低到0.5以下后，恢复
 # 此值越大，队列越接近满状态，加速线程执行的时间越提前。"加速"可能对接口接收服务造成压力，谨慎使用！
@@ -144,6 +144,7 @@ private static GrowingAPI project = new GrowingAPI.Builder().setProjectKey("your
 |addItem|(string, string)|否|物品模型ID, 物品模型KEY。|
 
 **代码示例**
+
 ```java
 GioCdpEventMessage msg = new GioCdpEventMessage.Builder()
                     .eventTime(System.currentTimeMillis())            // 默认为系统当前时间 (选填)
@@ -168,8 +169,7 @@ GioCdpEventMessage msg = new GioCdpEventMessage.Builder()
 |addUserVariable|(string, string\|double\|int)|否|用户变量。|
 |addUserVariables|map<string,object>|否|用户变量集合。|
 
-
-示例代码：
+**代码示例**
 
 ```java
 GioCdpUserMessage msg = new GioCdpUserMessage.Builder()
@@ -190,6 +190,8 @@ GioCdpUserMessage msg = new GioCdpUserMessage.Builder()
 |key|string|是|物品模型KEY。|
 |addItemVariable|map<string,string>|否|物品模型变量。|
 
+**代码示例**
+
 ```java
 GioCdpItemMessage msg = new GioCdpItemMessage.Builder()
                 .id("1001")                        // 物品模型ID (必填)
@@ -205,8 +207,7 @@ GioCdpItemMessage msg = new GioCdpItemMessage.Builder()
 |addUserVariable|(string, string)|否|用户KEY, 用户ID。|
 |addUserVariables|map<string,string>|否|(用户KEY, 用户ID)集合。|
 
-
-示例代码：
+**代码示例**
 
 ```java
 GioCdpUserMappingMessage msg = new GioCdpUserMappingMessage.Builder()

--- a/deploy-cdp-snapshot.sh
+++ b/deploy-cdp-snapshot.sh
@@ -4,6 +4,8 @@
 # 需要配置 maven 中央仓库的账号
 # 用户名 dev-growing
 # 密码 联系 wangtong@growingio.com, aiyanbo@growingio.com
-# m1 上增加-Papple-silicon执行相关命令
 
 mvn -s ~/.m2/settings-gio-sdk.xml clean install deploy -Pcdp -Dmaven.test.skip=true -Dgpg.skip=true
+
+# Apple m1 上增加-Papple-silicon 执行相关命令进行打包
+mvn clean install -Papple-silicon -Pcdp -Dmaven.test.skip=true -Dgpg.skip=true

--- a/gio-sdk-java-demo/src/main/java/io/growing/sdk/java/demo/Demo.java
+++ b/gio-sdk-java-demo/src/main/java/io/growing/sdk/java/demo/Demo.java
@@ -26,6 +26,7 @@ public class Demo {
         sendCdpItem();
         sendCdpCustomEvent();
         sendCdpUser();
+        GrowingAPI.shutdown();
     }
 
     /**

--- a/src/main/java/io/growing/sdk/java/GrowingAPI.java
+++ b/src/main/java/io/growing/sdk/java/GrowingAPI.java
@@ -132,4 +132,18 @@ public class GrowingAPI {
     public static void initConfig(Properties properties) {
         ConfigUtils.init(properties);
     }
+
+    /**
+     * showdownNow 将会直接调用sdk中线程池的shutdownNow.
+     */
+    public static void shutdownNow() {
+        strategy.shutDownNow();
+    }
+
+    /**
+     * shutdown 将会依照配置信息，允许执行之前提交的任务直到完成或超时.
+     */
+    public static void shutdown() {
+        strategy.awaitTerminationAfterShutdown();
+    }
 }

--- a/src/main/java/io/growing/sdk/java/sender/FixThreadPoolSender.java
+++ b/src/main/java/io/growing/sdk/java/sender/FixThreadPoolSender.java
@@ -7,6 +7,7 @@ import io.growing.sdk.java.sender.net.HttpUrlProvider;
 import io.growing.sdk.java.sender.net.NetProviderAbstract;
 import io.growing.sdk.java.thread.GioThreadNamedFactory;
 import io.growing.sdk.java.utils.ConfigUtils;
+import io.growing.sdk.java.utils.ExecutorServiceUtils;
 
 import java.util.List;
 import java.util.concurrent.ExecutorService;
@@ -56,4 +57,13 @@ public class FixThreadPoolSender implements MessageSender {
         }
     }
 
+    @Override
+    public void shutdownNow() {
+        sendThread.shutdownNow();
+    }
+
+    @Override
+    public void awaitTermination(long timeout) {
+        ExecutorServiceUtils.awaitTerminationAfterShutdown(sendThread, timeout);
+    }
 }

--- a/src/main/java/io/growing/sdk/java/sender/MessageSender.java
+++ b/src/main/java/io/growing/sdk/java/sender/MessageSender.java
@@ -13,4 +13,8 @@ public interface MessageSender {
 
     void sendMsg(final String projectKey, final List<GIOMessage> msg);
 
+    void shutdownNow();
+
+    void awaitTermination(long timeout);
+
 }

--- a/src/main/java/io/growing/sdk/java/store/StoreStrategy.java
+++ b/src/main/java/io/growing/sdk/java/store/StoreStrategy.java
@@ -11,6 +11,10 @@ public interface StoreStrategy {
 
     void push(GIOMessage msgList);
 
-    void shutdownAwait();
+    void registerShutdownHook();
+
+    void awaitTerminationAfterShutdown();
+
+    void shutDownNow();
 
 }

--- a/src/main/java/io/growing/sdk/java/store/StoreStrategyClient.java
+++ b/src/main/java/io/growing/sdk/java/store/StoreStrategyClient.java
@@ -29,7 +29,7 @@ public class StoreStrategyClient {
         } else {
             storeStrategy = DefaultStoreInstance.defaultStoreStrategy;
         }
-        storeStrategy.shutdownAwait();
+        storeStrategy.registerShutdownHook();
         return storeStrategy;
     }
 

--- a/src/main/java/io/growing/sdk/java/utils/ExecutorServiceUtils.java
+++ b/src/main/java/io/growing/sdk/java/utils/ExecutorServiceUtils.java
@@ -1,0 +1,23 @@
+package io.growing.sdk.java.utils;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeUnit;
+
+public class ExecutorServiceUtils {
+
+    public static void awaitTerminationAfterShutdown(ExecutorService threadPool, long timeout) {
+        awaitTerminationAfterShutdown(threadPool, timeout, TimeUnit.MILLISECONDS);
+    }
+
+    public static void awaitTerminationAfterShutdown(ExecutorService threadPool, long timeout, TimeUnit unit) {
+        threadPool.shutdown();
+        try {
+            if (!threadPool.awaitTermination(timeout, unit)) {
+                threadPool.shutdownNow();
+            }
+        } catch (InterruptedException ex) {
+            threadPool.shutdownNow();
+            Thread.currentThread().interrupt();
+        }
+    }
+}


### PR DESCRIPTION
## PR 内容
* 修正并发可能导致shutdown是await设置失效，表现为单测结束时，jvm shutdownhook未生效导致事件为发送
* 增加shutdown和shutdownNow接口，主线程结束后，可以正常结束进程
* 修正文档，proxy默认不设置，增加gio.properties的位置说明
* 增加配置, 分别对应sdk中所有线程池在执行shutdown时的超时时间， 单位为ms
1. push.thread_pool.timeout
2. send.thread_pool.timeout
3. sender.thread_pool.timeout
4. speed.thread_pool.timeout

## 测试步骤
* 在DefaultStoreStrategy.java中增加如下代码, 测试可能存在的并发问题
```java
private static volatile boolean shutdown = false; // 增加静态变量shutdown
...
while (!messageBlockingQueue.isEmpty() || !shutdown)  { // while判断增加 || !shutdown
...
shutdown = true; // 增加shutdown为true
if (!messageBlockingQueue.isEmpty()) { // 测试时保证if循环中日志不输出，即复现该问题
```

## 影响范围
* 退出应用时，可能丢失未及时发送的数据
* 进程中其他线程结束，sdk中线程无法结束导致进程无法退出

## 是否属于重要变动？

- [x] 是
- [ ] 否

## 其他信息