### PR TITLE
fix: adapt gradle

### DIFF
--- a/deploy-cdp-snapshot.sh
+++ b/deploy-cdp-snapshot.sh
@@ -8,4 +8,4 @@
 mvn -s ~/.m2/settings-gio-sdk.xml clean install deploy -Pcdp -Dmaven.test.skip=true -Dgpg.skip=true
 
 # Apple m1 上增加-Papple-silicon 执行相关命令进行打包
-mvn clean install -Papple-silicon -Pcdp -Dmaven.test.skip=true -Dgpg.skip=true
+mvn clean install -Papple-silicon,cdp-release -Dmaven.test.skip=true -Dgpg.skip=true

--- a/gio-sdk-java-demo/pom.xml
+++ b/gio-sdk-java-demo/pom.xml
@@ -31,7 +31,7 @@
         <dependency>
             <groupId>io.growing.sdk.java</groupId>
             <artifactId>growingio-java-sdk</artifactId>
-            <version>1.0.10-cdp-SNAPSHOT</version>
+            <version>1.0.11-cdp-SNAPSHOT</version>
             <classifier>standalone</classifier>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
         <jdk.version>1.6</jdk.version>
         <downloadSources>true</downloadSources>
         <!-- 低版本 release 之后，此 version 需要升级，避免 低版本 snapshot 重复 deploy -->
-        <gio-java-sdk-version>1.0.10</gio-java-sdk-version>
+        <gio-java-sdk-version>1.0.11</gio-java-sdk-version>
     </properties>
 
     <dependencies>
@@ -257,6 +257,39 @@
                         </configuration>
                     </execution>
                 </executions>
+            </plugin>
+            <!-- replace ${} referenced from https://stackoverflow.com/questions/40308600/replace-properties-with-its-values-in-pom-xml-before-putting-the-pom-file-into -->
+            <plugin>
+                <artifactId>maven-resources-plugin</artifactId>
+                <version>3.0.1</version>
+                <executions>
+                    <execution>
+                        <id>copy-resources</id>
+                        <phase>validate</phase>
+                        <goals>
+                            <goal>copy-resources</goal>
+                        </goals>
+                        <configuration>
+                            <resources>
+                                <resource>
+                                    <directory>./</directory>
+                                    <includes>
+                                        <include>pom.xml</include>
+                                    </includes>
+                                    <filtering>true</filtering>
+                                </resource>
+                            </resources>
+                            <outputDirectory>target</outputDirectory>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-install-plugin</artifactId>
+                <configuration>
+                    <pomFile>target/pom.xml</pomFile>
+                </configuration>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
## PR 内容
替换发版pom文件中占位符为实际值
maven中pom.xml不符合最佳实践, version使用占位符指定, 并且使用了profile及activeByDefault指定, gradle解析时对profile的支持如下
```
Profiles that are active by default (available with Gradle 1.12 and higher)
Profiles that are active on the absence of a system property (available with Gradle 2.0 and higher)
```
导致gradle认为version版本号为1.0.10-SNAPSHOT, 与实际依赖版本不符合

问题复现步骤
1. 新建gradle项目，配置依赖implementation "io.growing.sdk.java:growingio-java-sdk:1.0.10-cdp"
2. 报错 Could not resolve io.growing.sdk.java:growingio-java-sdk:1.0.10-cdp.
3. 通过.gradlew :dependencies --scan 得到具体信息

```
inconsistent module metadata found. Descriptor: io.growing.sdk.java:growingio-java-sdk:1.0.10-SNAPSHOT Errors: bad version: expected='1.0.10-cdp' found='1.0.10-SNAPSHOT'
```

## 测试步骤
1. mvn clean install -Papple-silicon,cdp-release -Dmaven.test.skip=true -Dgpg.skip=true 发版到本地
2. 测试maven和gradle项目添加mavenLocal()仓库，测试是否能够正常拉取到jar以及依赖
3. 测试java demo中api能够正常调用

## 影响范围
影响发版后的pom.xml, gradle和maven分别拉取时解析的metadata

## 是否属于重要变动？

- [x] 是
- [ ] 否

## 其他信息
maven最佳实践 https://dzone.com/articles/maven-profile-best-practices
gradle对maven pom profile的支持范围 https://blog.gradle.org/maven-pom-profiles
