### PR TITLE
fix: 修正run.mode静态变量在initConfig前初始化

### DIFF
--- a/src/main/java/io/growing/sdk/java/GrowingAPI.java
+++ b/src/main/java/io/growing/sdk/java/GrowingAPI.java
@@ -21,17 +21,17 @@ import java.util.Properties;
  */
 public class GrowingAPI {
 
-    private static final boolean validDefaultConfig;
+    private final boolean validDefaultConfig;
     private final String projectKey;
     private final String dataSourceId;
     private static final StoreStrategy strategy = StoreStrategyClient.getStoreInstance(StoreStrategyClient.CURRENT_STRATEGY);
 
     static {
         ConfigUtils.initDefault();
-        validDefaultConfig = validDefaultConfig();
     }
 
     private GrowingAPI(Builder builder) {
+        this.validDefaultConfig = validDefaultConfig();
         this.dataSourceId = builder.dataSourceId;
         this.projectKey = builder.projectKey;
     }

--- a/src/test/java/io/growing/sdk/java/test/GrowingAPITest.java
+++ b/src/test/java/io/growing/sdk/java/test/GrowingAPITest.java
@@ -11,6 +11,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
 import java.util.HashMap;
+import java.util.Properties;
 
 
 /**
@@ -24,6 +25,9 @@ public class GrowingAPITest {
 
     @BeforeClass
     public static void before() {
+        Properties properties = new Properties();
+        properties.setProperty("run.mode", "test");
+        GrowingAPI.initConfig(properties);
         sender = new GrowingAPI.Builder().setDataSourceId("a390a68c7b25638c").setProjectKey("91eaf9b283361032").build();
     }
 


### PR DESCRIPTION
## PR 内容
修正run.mode对应的静态变量在initConfig前初始化

## 测试步骤
修改前，GrowingAPITest中，通过initConfig设置run.mode为test/production无效，仅依照test/java/resources/gio.properties中的配置执行
修改后，GrowingAPITest中，通过initConfig设置run.mode为test/production有效，根据设置的run.mode执行
效果参考日志：[main] growingio-java-sdk version is 1.0.10-cdp, running in mode: TEST

## 影响范围
初始化配置，用户自定义配置文件或Properties时，run.mode设置无效

## 是否属于重要变动？
- [ ] 是
- [x] 否

## 其他信息
无