### PR TITLE
feat: 支持设置sendtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ private static GrowingAPI project = new GrowingAPI.Builder().setProjectKey("your
 
 |参数名称|类型|是否必填|说明|
 | --- | --- | --- | --- |
-|eventTime|long|否|事件发生时间。|
+|eventTime|long|否|事件发生时间。需要开启“自定义event_time上报”功能方可生效，请联系技术支持确认|
 |eventKey|string|是|埋点事件的KEY。|
 |anonymousId|string|否|匿名用户ID。|
 |loginUserKey|string|否|登录用户KEY。|

--- a/src/main/java/io/growing/sdk/java/dto/GioCdpEventMessage.java
+++ b/src/main/java/io/growing/sdk/java/dto/GioCdpEventMessage.java
@@ -59,6 +59,7 @@ public class GioCdpEventMessage extends GioCDPMessage<EventV3Dto> implements Ser
 
         public Builder eventTime(long eventTime) {
             builder.setTimestamp(eventTime);
+            builder.setSendTime(eventTime);
             return this;
         }
 

--- a/src/main/java/io/growing/sdk/java/dto/GioCdpUserMappingMessage.java
+++ b/src/main/java/io/growing/sdk/java/dto/GioCdpUserMappingMessage.java
@@ -53,14 +53,19 @@ public class GioCdpUserMappingMessage extends GioCDPMessage<UserMappingDto> impl
             return new GioCdpUserMappingMessage(builder);
         }
 
-        public GioCdpUserMappingMessage.Builder addIdentities(String userKey, String userId) {
+        public Builder eventTime(long eventTime) {
+            builder.setSendTime(eventTime);
+            return this;
+        }
+
+        public Builder addIdentities(String userKey, String userId) {
             if (userKey != null && userId != null) {
                 builder.putIdentifies(userKey, userId);
             }
             return this;
         }
 
-        public GioCdpUserMappingMessage.Builder addIdentities(Map<String, String> identifies) {
+        public Builder addIdentities(Map<String, String> identifies) {
             if (identifies != null && !identifies.isEmpty()) {
                 builder.putAllIdentifies(identifies);
             }

--- a/src/main/java/io/growing/sdk/java/dto/GioCdpUserMessage.java
+++ b/src/main/java/io/growing/sdk/java/dto/GioCdpUserMessage.java
@@ -58,6 +58,7 @@ public class GioCdpUserMessage extends GioCDPMessage<EventV3Dto> implements Seri
 
         public Builder time(long timestamp) {
             builder.setTimestamp(timestamp);
+            builder.setSendTime(timestamp);
             return this;
         }
 

--- a/src/test/java/io/growing/sdk/java/test/GrowingAPITest.java
+++ b/src/test/java/io/growing/sdk/java/test/GrowingAPITest.java
@@ -42,7 +42,7 @@ public class GrowingAPITest {
         resourceAttributes.put("resource_attribute_key", "resource_attribute_value");
 
         sender.send(new GioCdpEventMessage.Builder()
-                        .eventTime(System.currentTimeMillis())
+                        .eventTime(System.currentTimeMillis() - 24 * 60 * 60 * 1000)
                         .loginUserKey("login_user_key")
                         .loginUserId("login_user_id")
                         .anonymousId("anonymous_id")
@@ -68,7 +68,7 @@ public class GrowingAPITest {
         attributes.put("string_attribute_key", "string_attribute_value");
 
         sender.send(new GioCdpUserMessage.Builder()
-                .time(System.currentTimeMillis())
+                .time(System.currentTimeMillis() - 24 * 60 * 60 * 1000)
                 .loginUserKey("login_user_key")
                 .loginUserId("login_user_id")
                 .anonymousId("anonymous_id")
@@ -105,6 +105,7 @@ public class GrowingAPITest {
         identities.put("email", "unit-test@growingio.com");
         identities.put("qq", "26******20");
         sender.send(new GioCdpUserMappingMessage.Builder()
+                .eventTime(System.currentTimeMillis() - 24 * 60 * 60 * 1000)
                 .addIdentities("phone", "1**********1")
                 .addIdentities("login_user_key", "login_user_id")
                 .addIdentities(identities)


### PR DESCRIPTION
## PR 内容
event_time设置同时设置给client_time和event_time

## 测试步骤
发送sendtime字段到cdp测试平台，数据库查数对照client_time和event_time

## 影响范围
事件可设置字段增加

## 是否属于重要变动？

- [ ] 是
- [x] 否

## 其他信息
client_time 在这种情况下无法用来确认具体的发送时间
库中client_time与event_time相同的场景为用户导入数据或服务端sdk主动设置的时间的时间

