### PR TITLE
feat: 支持user和custom列表属性

### DIFF
--- a/src/main/java/io/growing/sdk/java/dto/GioCdpEventMessage.java
+++ b/src/main/java/io/growing/sdk/java/dto/GioCdpEventMessage.java
@@ -6,6 +6,8 @@ import io.growing.collector.tunnel.protocol.ResourceItem;
 import io.growing.sdk.java.logger.GioLogger;
 
 import java.io.Serializable;
+import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -52,6 +54,7 @@ public class GioCdpEventMessage extends GioCDPMessage<EventV3Dto> implements Ser
 
     public static final class Builder {
         private final EventV3Dto.Builder builder = EventV3Dto.newBuilder();
+        private static final String LIST_SPLIT = "||";
 
         public GioCdpEventMessage build() {
             return new GioCdpEventMessage(builder);
@@ -120,6 +123,31 @@ public class GioCdpEventMessage extends GioCDPMessage<EventV3Dto> implements Ser
                 }
             }
             return this;
+        }
+
+        public <T> Builder addEventVariable(String key, List<T> value) {
+            if (key != null && value != null && !value.isEmpty()) {
+                StringBuilder valueBuilder = new StringBuilder();
+                Iterator<T> iterator = value.iterator();
+                if (iterator.hasNext()) {
+                    valueBuilder.append(toString(iterator.next()));
+                    while (iterator.hasNext()) {
+                        valueBuilder.append(LIST_SPLIT);
+                        valueBuilder.append(toString(iterator.next()));
+                    }
+                }
+                builder.putAttributes(key, valueBuilder.toString());
+            }
+
+            return this;
+        }
+
+        private String toString(Object value) {
+            if (value == null) {
+                return "";
+            } else {
+                return String.valueOf(value);
+            }
         }
 
         public Builder addItem(String id, String key) {

--- a/src/main/java/io/growing/sdk/java/dto/GioCdpUserMessage.java
+++ b/src/main/java/io/growing/sdk/java/dto/GioCdpUserMessage.java
@@ -5,6 +5,8 @@ import io.growing.collector.tunnel.protocol.EventV3Dto;
 import io.growing.sdk.java.logger.GioLogger;
 
 import java.io.Serializable;
+import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -51,6 +53,7 @@ public class GioCdpUserMessage extends GioCDPMessage<EventV3Dto> implements Seri
 
     public static final class Builder {
         private EventV3Dto.Builder builder = EventV3Dto.newBuilder();
+        private static final String LIST_SPLIT = "||";
 
         public GioCdpUserMessage build() {
             return new GioCdpUserMessage(builder);
@@ -97,6 +100,31 @@ public class GioCdpUserMessage extends GioCDPMessage<EventV3Dto> implements Seri
         public Builder addUserVariable(String key, double value) {
             this.addVariableObject(key, value);
             return this;
+        }
+
+        public <T> Builder addUserVariable(String key, List<T> value) {
+            if (key != null && value != null && !value.isEmpty()) {
+                StringBuilder valueBuilder = new StringBuilder();
+                Iterator<T> iterator = value.iterator();
+                if (iterator.hasNext()) {
+                    valueBuilder.append(toString(iterator.next()));
+                    while (iterator.hasNext()) {
+                        valueBuilder.append(LIST_SPLIT);
+                        valueBuilder.append(toString(iterator.next()));
+                    }
+                }
+                builder.putAttributes(key, valueBuilder.toString());
+            }
+
+            return this;
+        }
+
+        private String toString(Object value) {
+            if (value == null) {
+                return "";
+            } else {
+                return String.valueOf(value);
+            }
         }
 
         private Builder addVariableObject(String key, Object value) {

--- a/src/test/java/io/growing/sdk/java/test/GrowingAPITest.java
+++ b/src/test/java/io/growing/sdk/java/test/GrowingAPITest.java
@@ -10,6 +10,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Properties;
 
@@ -40,7 +41,6 @@ public class GrowingAPITest {
 
         HashMap<String, String> resourceAttributes = new HashMap<String, String>();
         resourceAttributes.put("resource_attribute_key", "resource_attribute_value");
-
         sender.send(new GioCdpEventMessage.Builder()
                         .eventTime(System.currentTimeMillis() - 24 * 60 * 60 * 1000)
                         .loginUserKey("login_user_key")
@@ -49,6 +49,8 @@ public class GrowingAPITest {
                         .eventKey("event_name")
                         .addItem("resource_item_id", "resource_item_key", resourceAttributes)
                         .addEventVariable("attribute_key", "attribute_value")
+                        .addEventVariable("attribute_list_key", Arrays.asList("", "1", null))
+                        .addEventVariable("empty_list_key", Arrays.asList())
                         .addEventVariables(attributes)
                         .build());
     }
@@ -73,6 +75,8 @@ public class GrowingAPITest {
                 .loginUserId("login_user_id")
                 .anonymousId("anonymous_id")
                 .addUserVariable("attribute_key", "attribute_value")
+                .addUserVariable("attribute_list_key", Arrays.asList("", "1", null))
+                .addUserVariable("empty_list_key", Arrays.asList())
                 .addUserVariables(attributes)
                 .build());
     }

--- a/src/test/java/io/growing/sdk/java/test/MockHttpTest.java
+++ b/src/test/java/io/growing/sdk/java/test/MockHttpTest.java
@@ -1,0 +1,143 @@
+package io.growing.sdk.java.test;
+
+import io.growing.collector.tunnel.protocol.EventV3Dto;
+import io.growing.collector.tunnel.protocol.EventV3List;
+import io.growing.sdk.java.GrowingAPI;
+import io.growing.sdk.java.dto.GioCdpEventMessage;
+import io.growing.sdk.java.dto.GioCdpUserMessage;
+import io.growing.sdk.java.test.stub.StubStreamHandlerFactory;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import java.net.URL;
+import java.util.*;
+import java.util.concurrent.CountDownLatch;
+
+@RunWith(JUnit4.class)
+public class MockHttpTest {
+    private static final String PROJECT_KEY = "91eaf9b283361032";
+    private static final String DATASOURCE_ID = "a390a68c7b25638c";
+
+    private static GrowingAPI sender;
+    private static StubStreamHandlerFactory factory;
+
+    @BeforeClass
+    public static void before() {
+        Properties properties = new Properties();
+        properties.setProperty("run.mode", "production");
+        GrowingAPI.initConfig(properties);
+        sender = new GrowingAPI.Builder().setDataSourceId(DATASOURCE_ID).setProjectKey(PROJECT_KEY).build();
+        factory = new StubStreamHandlerFactory();
+        URL.setURLStreamHandlerFactory(factory);
+    }
+
+    @Test
+    public void sendCustomEvent() throws InterruptedException {
+        final CountDownLatch countDownLatch = new CountDownLatch(1);
+
+        factory.setStubHttpURLConnectionListener(new StubStreamHandlerFactory.StubHttpURLConnectionListener() {
+            @Override
+            public void onSend(URL url, byte[] msg) {
+                try {
+                    EventV3List eventList = EventV3List.parseFrom(msg);
+                    EventV3Dto customEvent = eventList.getValues(0);
+                    Assert.assertEquals(DATASOURCE_ID, customEvent.getDataSourceId());
+                    Assert.assertEquals(PROJECT_KEY, customEvent.getProjectKey());
+
+                    Assert.assertEquals("CUSTOM", customEvent.getEventType().name());
+                    Assert.assertEquals("list_attribute_test_event", customEvent.getEventName());
+
+                    Map<String, String> attributes = customEvent.getAttributesMap();
+                    Assert.assertEquals("1||2||3", attributes.get("list_attribute_normal"));
+                    Assert.assertEquals("||1||", attributes.get("list_attribute_contains_null"));
+                    Assert.assertNull(attributes.get("list_attribute_empty"));
+                    Assert.assertEquals("", attributes.get("list_attribute_empty_string"));
+                    Assert.assertEquals("||||", attributes.get("list_attribute_empty_string_list"));
+                    Assert.assertEquals("", attributes.get(""));
+                    Assert.assertEquals("中文||English||にほんご", attributes.get("列表属性中文"));
+                    Assert.assertEquals(101, attributes.get("list_attribute_length").split("\\|\\|").length);
+
+                } catch (Exception e) {
+                    Assert.fail();
+                }
+
+                countDownLatch.countDown();
+            }
+        });
+
+        sender.send(new GioCdpEventMessage.Builder()
+                .eventKey("list_attribute_test_event")
+                .addEventVariable("list_attribute_normal", Arrays.asList("1", "2", "3"))
+                .addEventVariable("list_attribute_contains_null", Arrays.asList("", "1", null))
+                .addEventVariable("list_attribute_empty", Arrays.asList())
+                .addEventVariable("list_attribute_empty_string", Arrays.asList(""))
+                .addEventVariable("list_attribute_empty_string_list", Arrays.asList("", "", ""))
+                .addEventVariable("", Arrays.asList(""))
+                .addEventVariable("列表属性中文", Arrays.asList("中文", "English", "にほんご"))
+                .addEventVariable("list_attribute_length", makeSequence(0, 100))
+                .build());
+
+       countDownLatch.await();
+    }
+
+    @Test
+    public void sendUserEvent() throws InterruptedException {
+        final CountDownLatch countDownLatch = new CountDownLatch(1);
+
+        factory.setStubHttpURLConnectionListener(new StubStreamHandlerFactory.StubHttpURLConnectionListener() {
+            @Override
+            public void onSend(URL url, byte[] msg) {
+                try {
+                    EventV3List eventList = EventV3List.parseFrom(msg);
+                    EventV3Dto userEvent = eventList.getValues(0);
+                    Assert.assertEquals(DATASOURCE_ID, userEvent.getDataSourceId());
+                    Assert.assertEquals(PROJECT_KEY, userEvent.getProjectKey());
+
+                    Assert.assertEquals("LOGIN_USER_ATTRIBUTES", userEvent.getEventType().name());
+                    Assert.assertEquals("list_attribute_test_user", userEvent.getUserId());
+
+                    Map<String, String> attributes = userEvent.getAttributesMap();
+                    Assert.assertEquals("1||2||3", attributes.get("list_attribute_normal"));
+                    Assert.assertEquals("||1||", attributes.get("list_attribute_contains_null"));
+                    Assert.assertNull(attributes.get("list_attribute_empty"));
+                    Assert.assertEquals("", attributes.get("list_attribute_empty_string"));
+                    Assert.assertEquals("||||", attributes.get("list_attribute_empty_string_list"));
+                    Assert.assertEquals("", attributes.get(""));
+                    Assert.assertEquals("中文||English||にほんご", attributes.get("列表属性中文"));
+                    Assert.assertEquals(101, attributes.get("list_attribute_length").split("\\|\\|").length);
+
+                } catch (Exception e) {
+                    Assert.fail();
+                }
+
+                countDownLatch.countDown();
+            }
+        });
+
+        sender.send(new GioCdpUserMessage.Builder()
+                .loginUserId("list_attribute_test_user")
+                .addUserVariable("list_attribute_normal", Arrays.asList("1", "2", "3"))
+                .addUserVariable("list_attribute_contains_null", Arrays.asList("", "1", null))
+                .addUserVariable("list_attribute_empty", Arrays.asList())
+                .addUserVariable("list_attribute_empty_string", Arrays.asList(""))
+                .addUserVariable("list_attribute_empty_string_list", Arrays.asList("", "", ""))
+                .addUserVariable("", Arrays.asList(""))
+                .addUserVariable("列表属性中文", Arrays.asList("中文", "English", "にほんご"))
+                .addUserVariable("list_attribute_length", makeSequence(0, 100))
+                .build());
+
+        countDownLatch.await();
+    }
+
+    // Java 8可以使用Stream API
+    private List<Integer> makeSequence(int begin, int end) {
+        List<Integer> ret = new ArrayList(end - begin + 1);
+
+        for(int i = begin; i <= end; i++, ret.add(i));
+
+        return ret;
+    }
+}

--- a/src/test/java/io/growing/sdk/java/test/stub/StubStreamHandlerFactory.java
+++ b/src/test/java/io/growing/sdk/java/test/stub/StubStreamHandlerFactory.java
@@ -1,0 +1,73 @@
+package io.growing.sdk.java.test.stub;
+
+import java.io.*;
+import java.net.*;
+
+public class StubStreamHandlerFactory implements URLStreamHandlerFactory {
+    private StubHttpURLConnectionListener mStubHttpURLConnectionListener;
+
+    @Override
+    public URLStreamHandler createURLStreamHandler(String protocol) {
+        return new StubHttpURLStreamHandler();
+    }
+
+    public void setStubHttpURLConnectionListener(StubHttpURLConnectionListener httpURLConnectionListener) {
+        this.mStubHttpURLConnectionListener = httpURLConnectionListener;
+    }
+
+    private class StubHttpURLStreamHandler extends URLStreamHandler {
+        @Override
+        protected URLConnection openConnection(URL url) {
+            return new StubHttpURLConnection(url);
+        }
+    }
+
+    private class StubHttpURLConnection extends HttpURLConnection {
+
+        public StubHttpURLConnection(URL url) {
+            super(url);
+        }
+
+        @Override
+        public void connect() {
+            // do nothing
+        }
+
+        @Override
+        public void disconnect() {
+            // do nothing
+        }
+
+        @Override
+        public OutputStream getOutputStream() throws IOException {
+            return new ByteArrayOutputStream() {
+                @Override
+                public void close() throws IOException {
+                    if (mStubHttpURLConnectionListener != null) {
+                        mStubHttpURLConnectionListener.onSend(StubHttpURLConnection.this.getURL(), this.toByteArray());
+                    }
+                    super.close();
+                }
+            };
+        }
+
+        @Override
+        public boolean usingProxy() {
+            return false;
+        }
+
+        @Override
+        public InputStream getInputStream() {
+            return new ByteArrayInputStream(new String("OK").getBytes());
+        }
+
+        @Override
+        public int getResponseCode() throws IOException {
+            return 204;
+        }
+    }
+
+    public interface StubHttpURLConnectionListener {
+        void onSend(URL url, byte[] msg);
+    }
+}


### PR DESCRIPTION
## PR 内容

<!-- 在下方描述你的PR实现了什么功能，或者修复了什么问题 -->
支持user和custom事件的属性为列表类型
增加MockHttp的测试进行列表属性校验


## 测试步骤

<!-- 请描述怎样操作才证明已经处理了问题. -->
参考单测中MockHttpTest
```java
sender.send(new GioCdpEventMessage.Builder()
                .eventKey("list_attribute_test_event")
                .addEventVariable("list_attribute_normal", Arrays.asList("1", "2", "3"))
                .addEventVariable("list_attribute_contains_null", Arrays.asList("", "1", null))
                .addEventVariable("list_attribute_empty", Arrays.asList())
                .addEventVariable("list_attribute_empty_string", Arrays.asList(""))
                .addEventVariable("list_attribute_empty_string_list", Arrays.asList("", "", ""))
                .addEventVariable("", Arrays.asList(""))
                .addEventVariable("列表属性中文", Arrays.asList("中文", "English", "にほんご"))
                .addEventVariable("list_attribute_length", makeSequence(0, 100))
                .build());

sender.send(new GioCdpUserMessage.Builder()
                .loginUserId("list_attribute_test_user")
                .addUserVariable("list_attribute_normal", Arrays.asList("1", "2", "3"))
                .addUserVariable("list_attribute_contains_null", Arrays.asList("", "1", null))
                .addUserVariable("list_attribute_empty", Arrays.asList())
                .addUserVariable("list_attribute_empty_string", Arrays.asList(""))
                .addUserVariable("list_attribute_empty_string_list", Arrays.asList("", "", ""))
                .addUserVariable("", Arrays.asList(""))
                .addUserVariable("列表属性中文", Arrays.asList("中文", "English", "にほんご"))
                .addUserVariable("list_attribute_length", makeSequence(0, 100))
                .build());
```


## 影响范围

<!-- 请描述你的PR能造成的影响范围. -->

用户属性及自定义事件上报

## 是否属于重要变动？

- [ ] 是
- [x] 否

## 其他信息

无

