### PR TITLE
fix: user检测条件更新

### DIFF
--- a/src/main/java/io/growing/sdk/java/dto/GioCdpUserMessage.java
+++ b/src/main/java/io/growing/sdk/java/dto/GioCdpUserMessage.java
@@ -3,6 +3,7 @@ package io.growing.sdk.java.dto;
 import io.growing.collector.tunnel.protocol.EventType;
 import io.growing.collector.tunnel.protocol.EventV3Dto;
 import io.growing.sdk.java.logger.GioLogger;
+import io.growing.sdk.java.utils.StringUtils;
 
 import java.io.Serializable;
 import java.util.Iterator;
@@ -43,8 +44,13 @@ public class GioCdpUserMessage extends GioCDPMessage<EventV3Dto> implements Seri
 
     @Override
     public boolean isIllegal() {
-        if (user.getUserId().isEmpty()) {
-            GioLogger.error("GioCdpUserMessage: userId is empty");
+        if (user.getAttributesMap().isEmpty()) {
+            GioLogger.error("GioCdpUserMessage: attributes is empty");
+            return true;
+        }
+
+        if (StringUtils.isBlank(user.getUserId()) && StringUtils.isBlank(user.getDeviceId())) {
+            GioLogger.error("GioCdpUserMessage: userId and anonymousId are empty");
             return true;
         }
 

--- a/src/test/java/io/growing/sdk/java/test/EventMessageTest.java
+++ b/src/test/java/io/growing/sdk/java/test/EventMessageTest.java
@@ -18,40 +18,58 @@ public class EventMessageTest {
                 .eventKey("event_name")
                 .loginUserId("user_id")
                 .build();
-        Assert.assertFalse("legal data: event_name and user_id ", eventMessage.isIllegal());
+        Assert.assertFalse(eventMessage.isIllegal());
 
         eventMessage = new GioCdpEventMessage.Builder()
                 .eventKey("event_name")
                 .anonymousId("device_id")
                 .build();
-        Assert.assertFalse("legal data: event_name and anonymousId ", eventMessage.isIllegal());
+        Assert.assertFalse(eventMessage.isIllegal());
 
         eventMessage = new GioCdpEventMessage.Builder()
                 .eventKey("event_name")
                 .build();
-        Assert.assertTrue("illegal data: event_name", eventMessage.isIllegal());
+        Assert.assertTrue(eventMessage.isIllegal());
 
         eventMessage = new GioCdpEventMessage.Builder()
                 .loginUserId("user_id")
                 .build();
-        Assert.assertTrue("illegal data: user_id", eventMessage.isIllegal());
+        Assert.assertTrue(eventMessage.isIllegal());
 
         eventMessage = new GioCdpEventMessage.Builder()
                 .anonymousId("device_id")
                 .build();
-        Assert.assertTrue("illegal data: device_id", eventMessage.isIllegal());
+        Assert.assertTrue(eventMessage.isIllegal());
     }
 
     @Test
     public void checkUserMessage() {
         GioCdpUserMessage userMessage = new GioCdpUserMessage.Builder()
                 .loginUserId("user_id")
+                .addUserVariable("attr_key", "attr_value")
                 .build();
-        Assert.assertFalse("legal data: user_id", userMessage.isIllegal());
+        Assert.assertFalse(userMessage.isIllegal());
 
         userMessage = new GioCdpUserMessage.Builder()
+                .anonymousId("anonymous_id")
+                .addUserVariable("attr_key", "attr_value")
                 .build();
-        Assert.assertTrue("illegal data: empty", userMessage.isIllegal());
+        Assert.assertFalse(userMessage.isIllegal());
+
+        userMessage = new GioCdpUserMessage.Builder()
+                .anonymousId("anonymous_id")
+                .build();
+        Assert.assertTrue(userMessage.isIllegal());
+
+        userMessage = new GioCdpUserMessage.Builder()
+                .loginUserId("user_id")
+                .build();
+        Assert.assertTrue(userMessage.isIllegal());
+
+        userMessage = new GioCdpUserMessage.Builder()
+                .addUserVariable("attr_key", "attr_value")
+                .build();
+        Assert.assertTrue(userMessage.isIllegal());
     }
 
     @Test
@@ -59,11 +77,11 @@ public class EventMessageTest {
         GioCdpUserMappingMessage userMappingMessage = new GioCdpUserMappingMessage.Builder()
                 .addIdentities("user_key", "user_id")
                 .build();
-        Assert.assertFalse("legal data: identity", userMappingMessage.isIllegal());
+        Assert.assertFalse(userMappingMessage.isIllegal());
 
         userMappingMessage = new GioCdpUserMappingMessage.Builder()
                 .build();
-        Assert.assertTrue("illegal data: empty", userMappingMessage.isIllegal());
+        Assert.assertTrue(userMappingMessage.isIllegal());
     }
 
     @Test
@@ -72,16 +90,16 @@ public class EventMessageTest {
                 .id("item_id")
                 .key("item_key")
                 .build();
-        Assert.assertFalse("legal data: item_id and item_key", itemMessage.isIllegal());
+        Assert.assertFalse(itemMessage.isIllegal());
 
         itemMessage = new GioCdpItemMessage.Builder()
                 .id("item_id")
                 .build();
-        Assert.assertTrue("illegal data: item_id", itemMessage.isIllegal());
+        Assert.assertTrue(itemMessage.isIllegal());
 
         itemMessage = new GioCdpItemMessage.Builder()
                 .key("item_key")
                 .build();
-        Assert.assertTrue("illegal data: item_key", itemMessage.isIllegal());
+        Assert.assertTrue(itemMessage.isIllegal());
     }
 }


### PR DESCRIPTION
## PR 内容

<!-- 在下方描述你的PR实现了什么功能，或者修复了什么问题 -->
user事件检测条件更新
userid/deviceid其中一个不为空，且attributes不为空
userid存在为登录用户属性，不存在且deviceid存在为访问用户属性

## 测试步骤

<!-- 请描述怎样操作才证明已经处理了问题. -->
参见测试用例EventMessageTest

## 影响范围

<!-- 请描述你的PR能造成的影响范围. -->
当不满足条件时不进行上报

## 是否属于重要变动？

- [ ] 是
- [x] 否

## 其他信息

无

