### PR TITLE
fix: 修复接口设置配置不生效

### DIFF
--- a/src/main/java/io/growing/sdk/java/GrowingAPI.java
+++ b/src/main/java/io/growing/sdk/java/GrowingAPI.java
@@ -24,7 +24,8 @@ public class GrowingAPI {
     private final boolean validDefaultConfig;
     private final String projectKey;
     private final String dataSourceId;
-    private static final StoreStrategy strategy = StoreStrategyClient.getStoreInstance(StoreStrategyClient.CURRENT_STRATEGY);
+
+    private static StoreStrategy strategy;
 
     static {
         ConfigUtils.initDefault();
@@ -32,6 +33,7 @@ public class GrowingAPI {
 
     private GrowingAPI(Builder builder) {
         this.validDefaultConfig = validDefaultConfig();
+        strategy = StoreStrategyClient.getStoreInstance(StoreStrategyClient.CURRENT_STRATEGY);
         this.dataSourceId = builder.dataSourceId;
         this.projectKey = builder.projectKey;
     }
@@ -137,13 +139,17 @@ public class GrowingAPI {
      * showdownNow 将会直接调用sdk中线程池的shutdownNow.
      */
     public static void shutdownNow() {
-        strategy.shutDownNow();
+        if (strategy != null) {
+            strategy.shutDownNow();
+        }
     }
 
     /**
      * shutdown 将会依照配置信息，允许执行之前提交的任务直到完成或超时.
      */
     public static void shutdown() {
-        strategy.awaitTerminationAfterShutdown();
+        if (strategy != null) {
+            strategy.awaitTerminationAfterShutdown();
+        }
     }
 }

--- a/src/main/java/io/growing/sdk/java/sender/net/HttpUrlProvider.java
+++ b/src/main/java/io/growing/sdk/java/sender/net/HttpUrlProvider.java
@@ -25,6 +25,7 @@ public class HttpUrlProvider extends NetProviderAbstract {
         try {
             return doSend(requestDto);
         } catch (Exception e) {
+            GioLogger.debug("failed to send request, cause " + e.getLocalizedMessage());
             if (e instanceof IOException) {
                 return retry(requestDto);
             } else {
@@ -113,8 +114,8 @@ public class HttpUrlProvider extends NetProviderAbstract {
                 TimeUnit.SECONDS.sleep(1);
                 responseCode = doSend(requestDto);
                 break;
-            } catch (Exception ignore) {
-
+            } catch (Exception e) {
+                GioLogger.debug("retry failed, cause " + e.getLocalizedMessage());
             }
         }
         return responseCode;

--- a/src/main/java/io/growing/sdk/java/utils/VersionInfo.java
+++ b/src/main/java/io/growing/sdk/java/utils/VersionInfo.java
@@ -8,7 +8,7 @@ package io.growing.sdk.java.utils;
 public class VersionInfo {
     private static String version = null;
 
-    private static final String defaultVersion = "1.0.10-cdp";
+    private static final String defaultVersion = "1.0.13-cdp";
 
     public static String getVersion() {
         if (version == null) {

--- a/src/test/java/io/growing/sdk/java/test/Case0PropertiesTest.java
+++ b/src/test/java/io/growing/sdk/java/test/Case0PropertiesTest.java
@@ -1,0 +1,84 @@
+package io.growing.sdk.java.test;
+
+import io.growing.sdk.java.GrowingAPI;
+import io.growing.sdk.java.constants.RunMode;
+import io.growing.sdk.java.logger.GioLogger;
+import io.growing.sdk.java.store.StoreStrategyClient;
+import io.growing.sdk.java.store.impl.AbortPolicyStoreStrategy;
+import io.growing.sdk.java.utils.ConfigUtils;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.util.Properties;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+@RunWith(JUnit4.class)
+public class Case0PropertiesTest {
+    private static final String PROJECT_KEY = "91eaf9b283361032";
+    private static final String DATASOURCE_ID = "a390a68c7b25638c";
+
+    private static GrowingAPI sender;
+
+    @Test
+    public void checkProperties() {
+        setStaticField(ConfigUtils.class, "inited", new AtomicBoolean(false));
+        setStaticField(RunMode.class, "currentMode", null);
+
+        // set properties
+        final String MAGINC_NUMBER = "666";
+
+        Properties properties = new Properties();
+
+        properties.setProperty("api.host", "http://localhost:8080");
+        properties.setProperty("project.id", "123456654321");
+        properties.setProperty("msg.store.strategy", "abortPolicy");
+        properties.setProperty("run.mode", "production");
+        properties.setProperty("logger.level", "error");
+
+        properties.setProperty("send.msg.thread", MAGINC_NUMBER);
+        properties.setProperty("send.msg.interval", MAGINC_NUMBER + 1);
+        properties.setProperty("msg.store.queue.size", MAGINC_NUMBER + 2);
+
+        // init properties
+        GrowingAPI.initConfig(properties);
+        sender = new GrowingAPI.Builder().setDataSourceId(DATASOURCE_ID).setProjectKey(PROJECT_KEY).build();
+
+        // check properties
+        Assert.assertEquals(ConfigUtils.getStringValue("api.host", ""), "http://localhost:8080");
+        Assert.assertEquals(ConfigUtils.getStringValue("project.id", ""), "123456654321");
+        Assert.assertEquals(StoreStrategyClient.CURRENT_STRATEGY.name(), "ABORT_POLICY");
+        Assert.assertTrue(RunMode.isProductionMode());
+        Assert.assertEquals(getStaticField(GioLogger.class, "loggerLevel"), "error");
+
+        Assert.assertEquals(getStaticField(AbortPolicyStoreStrategy.class, "THREADS"), Integer.parseInt(MAGINC_NUMBER));
+        Assert.assertEquals(getStaticField(AbortPolicyStoreStrategy.class, "SEND_INTERVAL"), Integer.parseInt(MAGINC_NUMBER + 1));
+        Assert.assertEquals(getStaticField(AbortPolicyStoreStrategy.class, "LIMIT"), Integer.parseInt(MAGINC_NUMBER + 2));
+    }
+
+    private static void setStaticField(Class clazz, String fieldName, Object value) {
+        try {
+            Field field = clazz.getDeclaredField(fieldName);
+            field.setAccessible(true);
+            Field modifiersField = Field.class.getDeclaredField("modifiers");
+            modifiersField.setAccessible(true);
+            modifiersField.setInt(field, field.getModifiers() & ~Modifier.FINAL);
+            field.set(null, value);
+        } catch (Exception ignored) {
+        }
+    }
+
+    private static Object getStaticField(Class clazz, String fieldName) {
+        try {
+            Field field = clazz.getDeclaredField(fieldName);
+            field.setAccessible(true);
+            return field.get(null);
+        } catch (Exception ignored) {
+        }
+
+        return null;
+    }
+}


### PR DESCRIPTION
## PR 内容

<!-- 在下方描述你的PR实现了什么功能，或者修复了什么问题 -->
GrowingAPI#initConfig接口设置的配置部分对发送策略不生效


## 测试步骤

<!-- 请描述怎样操作才证明已经处理了问题. -->

参考Case0PropertiesTest测试用例，GrowingAPI#initConfig接口设置的配置项中
send.msg.thread
send.msg.interval
等与发送策略相关配置不生效

## 影响范围

<!-- 请描述你的PR能造成的影响范围. -->

所有历史版本，通过GrowingAPI#initConfig接口设置配置不生效

## 是否属于重要变动？

- [ ] 是
- [x] 否

## 其他信息

无

