### PR TITLE
fix: the configuration file cannot be found in the IDE plugin

### DIFF
--- a/src/main/java/io/growing/sdk/java/sender/net/HttpUrlProvider.java
+++ b/src/main/java/io/growing/sdk/java/sender/net/HttpUrlProvider.java
@@ -73,22 +73,17 @@ public class HttpUrlProvider extends NetProviderAbstract {
         httpConn.setDoOutput(true);
 
         DataOutputStream outputStream = null;
-        InputStream inputStream = null;
         try {
             httpConn.connect();
             outputStream = new DataOutputStream(httpConn.getOutputStream());
             outputStream.write(requestDto.getBytes());
             outputStream.flush();
             int responseCode = httpConn.getResponseCode();
-            inputStream = httpConn.getInputStream();
 
             return responseOk(responseCode);
         } finally {
             if (outputStream != null) {
                 outputStream.close();
-            }
-            if (inputStream != null) {
-                inputStream.close();
             }
         }
     }

--- a/src/main/java/io/growing/sdk/java/utils/ConfigUtils.java
+++ b/src/main/java/io/growing/sdk/java/utils/ConfigUtils.java
@@ -1,5 +1,6 @@
 package io.growing.sdk.java.utils;
 
+import io.growing.sdk.java.GrowingAPI;
 import io.growing.sdk.java.exception.GIOMessageException;
 import io.growing.sdk.java.logger.GioLogger;
 
@@ -24,7 +25,15 @@ public class ConfigUtils {
         try {
             ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
             InputStream gioDefaultProps = classLoader.getResourceAsStream("gio_default.properties");
-            prop.load(gioDefaultProps);
+            if (gioDefaultProps != null) {
+                prop.load(gioDefaultProps);
+            } else {
+                // 通过加载GrowingAPI的ClassLoader来加载默认配置文件，IDE Plugin开发模式下，会使用自定义ClassLoader加载对应的plugin jar及dependencies
+                // 建议用户根据使用环境将对应properties配置文件加载到内存中直接通过init方法传入
+                ClassLoader defaultClassLoader = GrowingAPI.class.getClassLoader();
+                gioDefaultProps = defaultClassLoader.getResourceAsStream("gio_default.properties");
+                prop.load(gioDefaultProps);
+            }
 
             InputStream gioProps = classLoader.getResourceAsStream("gio.properties");
             if (gioProps != null) {


### PR DESCRIPTION
## PR 内容

fix:
1. 网络请求返回404，500无返回体时使用getErrStream而不是getInputStream（不在意响应体直接获取responseCode）
2. IDE Plugin开发时，插件和依赖的ClassLoader是CustomClassLoader，为当前线程上下文加载器的子加载器，导致无法找到对应的配置文件


## 测试步骤

1. 使用默认配置发送事件，抛出异常FileNotFoundException
2. 创建IDE Plugin项目，集成SDK，初始化报错cant find gio sdk config

## 影响范围

无

## 是否属于重要变动？

- [ ] 是
- [x] 否

## 其他信息

无

