### PR TITLE
feat: ab

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,6 +55,12 @@
         </dependency>
 
         <dependency>
+            <groupId>org.json</groupId>
+            <artifactId>json</artifactId>
+            <version>20140107</version>
+        </dependency>
+
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <version>4.12</version>

--- a/src/main/java/io/growing/sdk/java/GrowingAPI.java
+++ b/src/main/java/io/growing/sdk/java/GrowingAPI.java
@@ -1,15 +1,16 @@
 package io.growing.sdk.java;
 
+import io.growing.sdk.java.ab.ABTaskController;
+import io.growing.sdk.java.ab.ABTestCallback;
 import io.growing.sdk.java.constants.RunMode;
 import io.growing.sdk.java.dto.GIOMessage;
-import io.growing.sdk.java.dto.GioCDPMessage;
 import io.growing.sdk.java.exception.GIOSendBeRejectedException;
 import io.growing.sdk.java.logger.GioLogger;
 import io.growing.sdk.java.sender.FixThreadPoolSender;
 import io.growing.sdk.java.store.StoreStrategy;
 import io.growing.sdk.java.store.StoreStrategyClient;
 import io.growing.sdk.java.utils.ConfigUtils;
-import io.growing.sdk.java.utils.StringUtils;
+import io.growing.sdk.java.utils.MessageUtils;
 import io.growing.sdk.java.utils.VersionInfo;
 
 import java.util.Properties;
@@ -26,6 +27,8 @@ public class GrowingAPI {
     private final String dataSourceId;
 
     private static StoreStrategy strategy;
+    private static ABTaskController abTaskController;
+    private static boolean abEnabled = false;
 
     static {
         ConfigUtils.initDefault();
@@ -34,6 +37,10 @@ public class GrowingAPI {
     private GrowingAPI(Builder builder) {
         this.validDefaultConfig = validDefaultConfig();
         strategy = StoreStrategyClient.getStoreInstance(StoreStrategyClient.CURRENT_STRATEGY);
+        abEnabled = ConfigUtils.getBooleanValue("ab.enabled", false);
+        if (abEnabled) {
+            abTaskController = new ABTaskController(strategy);
+        }
         this.dataSourceId = builder.dataSourceId;
         this.projectKey = builder.projectKey;
     }
@@ -76,23 +83,30 @@ public class GrowingAPI {
         }
     }
 
-    private boolean businessVerification(GIOMessage msg) {
-        if (StringUtils.nonBlank(this.projectKey)) {
-            msg.setProjectKey(this.projectKey);
-        } else {
-            GioLogger.error("projectKey cant be null or empty string");
-            return false;
+    public void getABTest(String layerId, String dataSourceId, String distinctId, ABTestCallback callback) {
+        if (!abEnabled) {
+            return;
         }
+        try {
+            abTaskController.submitABTaskAsync(this.projectKey, dataSourceId, layerId, distinctId, callback);
+        } catch (Exception e) {
+            GioLogger.error("getABTest failed: " + e.getLocalizedMessage());
+        }
+    }
 
-        if (msg instanceof GioCDPMessage) {
-            if (StringUtils.nonBlank(this.dataSourceId)) {
-                ((GioCDPMessage<?>) msg).setDataSourceId(this.dataSourceId);
-            } else {
-                GioLogger.error("cdp message datasourceId cant be null or empty string");
-                return false;
-            }
+    public void getABTestSync(String layerId, String dataSourceId, String distinctId, ABTestCallback callback) {
+        if (!abEnabled) {
+            return;
         }
-        return true;
+        try {
+            abTaskController.submitABTaskSync(this.projectKey, dataSourceId, layerId, distinctId, callback);
+        } catch (Exception e) {
+            GioLogger.error("getABTest failed: " + e.getLocalizedMessage());
+        }
+    }
+
+    private boolean businessVerification(GIOMessage msg) {
+        return MessageUtils.businessVerification(msg, this.projectKey, this.dataSourceId);
     }
 
     public static class Builder {

--- a/src/main/java/io/growing/sdk/java/ab/ABExperiment.java
+++ b/src/main/java/io/growing/sdk/java/ab/ABExperiment.java
@@ -1,0 +1,89 @@
+package io.growing.sdk.java.ab;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
+
+public class ABExperiment {
+
+    private final String layerId;
+    private final long strategyId;
+    private final long experimentId;
+    private String expLayerName;
+    private String expName;
+    private String expStrategyName;
+    private final Map<String, String> variables;
+
+    public ABExperiment(String layerId, long strategyId, long experimentId, Map<String, String> variables) {
+        this.layerId = layerId;
+        this.strategyId = strategyId;
+        this.experimentId = experimentId;
+        if (variables == null) {
+            this.variables = Collections.emptyMap();
+        } else {
+            this.variables = variables;
+        }
+    }
+
+    public void setExperimentNames(String expLayerName, String expName, String expStrategyName) {
+        this.expLayerName = expLayerName;
+        this.expName = expName;
+        this.expStrategyName = expStrategyName;
+    }
+
+    public String getLayerId() {
+        return layerId;
+    }
+
+    public long getStrategyId() {
+        return strategyId;
+    }
+
+    public long getExperimentId() {
+        return experimentId;
+    }
+
+    public Map<String, String> getVariables() {
+        return variables;
+    }
+
+    public String getExpLayerName() {
+        return expLayerName;
+    }
+
+    public String getExpName() {
+        return expName;
+    }
+
+    public String getExpStrategyName() {
+        return expStrategyName;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj instanceof ABExperiment) {
+            ABExperiment abExperiment = (ABExperiment) obj;
+            return abExperiment.getLayerId().equals(layerId)
+                    && abExperiment.getStrategyId() == strategyId
+                    && abExperiment.getExperimentId() == experimentId
+                    && abExperiment.getVariables().equals(variables);
+        }
+        return super.equals(obj);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append(layerId).append("$").append(strategyId).append("$").append(experimentId);
+        if (variables != null && !variables.isEmpty()) {
+            Set<String> keySets = variables.keySet();
+            sb.append("$");
+            for (String key : keySets) {
+                sb.append(key).append("=").append(variables.get(key));
+            }
+        }
+        return sb.toString();
+    }
+
+
+}

--- a/src/main/java/io/growing/sdk/java/ab/ABTaskController.java
+++ b/src/main/java/io/growing/sdk/java/ab/ABTaskController.java
@@ -1,0 +1,73 @@
+package io.growing.sdk.java.ab;
+
+import io.growing.sdk.java.dto.GioCdpEventMessage;
+import io.growing.sdk.java.logger.GioLogger;
+import io.growing.sdk.java.store.StoreStrategy;
+import io.growing.sdk.java.thread.GioThreadNamedFactory;
+import io.growing.sdk.java.utils.MessageUtils;
+import io.growing.sdk.java.utils.StringUtils;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+public class ABTaskController {
+    private static final ExecutorService abTaskThreadPool = Executors.newSingleThreadExecutor(new GioThreadNamedFactory("gio-ab-sender"));
+    private static final ABTestHttpUrlProvider netProvider = new ABTestHttpUrlProvider();
+    private StoreStrategy strategy;
+
+    public ABTaskController(StoreStrategy strategy) {
+        this.strategy = strategy;
+    }
+
+    public void submitABTask(final String projectId, final String dataSourceId, final String layerId, final String distinctId, final ABTestCallback callback) {
+        if (StringUtils.isBlank(projectId) || StringUtils.isBlank(dataSourceId) || StringUtils.isBlank(distinctId) || callback == null) {
+            GioLogger.error("submitABTask:params is illegal");
+            return;
+        }
+
+        try {
+            ABTestResponse response = netProvider.requestABTestExperimentData(projectId, dataSourceId, layerId, distinctId);
+            if (response.isSucceed()) {
+                callback.onABExperimentReceived(response.abExperiment);
+                sendAbTestTrackEvent(response.abExperiment, projectId, dataSourceId, distinctId);
+            } else {
+                callback.onABExperimentFailed(new IllegalAccessException(response.getErrorMsg()));
+            }
+        } catch (Exception e) {
+            GioLogger.error("submitABTask failed: " + e.getLocalizedMessage());
+        }
+    }
+
+    public void submitABTaskSync(final String projectId, final String dataSourceId, final String layerId, final String distinctId, final ABTestCallback callback) {
+        submitABTask(projectId, dataSourceId, layerId, distinctId, callback);
+    }
+
+    public void submitABTaskAsync(final String projectId, final String dataSourceId, final String layerId, final String distinctId, final ABTestCallback callback) {
+        abTaskThreadPool.submit(new Runnable() {
+            @Override
+            public void run() {
+                submitABTask(projectId, dataSourceId, layerId, distinctId, callback);
+            }
+        });
+    }
+
+    private void sendAbTestTrackEvent(ABExperiment abExperiment, String projectId, String dataSourceId, String distinctId) {
+        if (abExperiment.getExperimentId() == 0 && abExperiment.getStrategyId() == 0) {
+            return;
+        }
+        GioCdpEventMessage eventMessage = new GioCdpEventMessage.Builder()
+                .eventKey("$exp_hit")
+                .anonymousId(distinctId)
+                .addEventVariable("$exp_id", String.valueOf(abExperiment.getExperimentId()))
+                .addEventVariable("$exp_strategy_id", String.valueOf(abExperiment.getStrategyId()))
+                .addEventVariable("$exp_layer_id", abExperiment.getLayerId())
+                .addEventVariable("$exp_layer_name", abExperiment.getExpLayerName())
+                .addEventVariable("$exp_name", abExperiment.getExpName())
+                .addEventVariable("$exp_strategy_name", abExperiment.getExpStrategyName())
+                .build();
+
+        if (MessageUtils.businessVerification(eventMessage, projectId, dataSourceId)) {
+            strategy.push(eventMessage);
+        }
+    }
+}

--- a/src/main/java/io/growing/sdk/java/ab/ABTestCallback.java
+++ b/src/main/java/io/growing/sdk/java/ab/ABTestCallback.java
@@ -1,0 +1,8 @@
+package io.growing.sdk.java.ab;
+
+public interface ABTestCallback {
+
+    void onABExperimentReceived(ABExperiment experiment);
+
+    void onABExperimentFailed(Exception error);
+}

--- a/src/main/java/io/growing/sdk/java/ab/ABTestHttpUrlProvider.java
+++ b/src/main/java/io/growing/sdk/java/ab/ABTestHttpUrlProvider.java
@@ -1,0 +1,111 @@
+package io.growing.sdk.java.ab;
+
+import io.growing.sdk.java.sender.net.BaseNetProvider;
+import io.growing.sdk.java.utils.ConfigUtils;
+
+import java.io.*;
+import java.net.HttpURLConnection;
+import java.net.Proxy;
+import java.net.URL;
+import java.net.URLEncoder;
+import java.nio.charset.Charset;
+
+public class ABTestHttpUrlProvider extends BaseNetProvider {
+
+    private static int getConnectionTimeout() {
+        return ConfigUtils.getIntValue("ab.connection.timeout", 5000);
+    }
+
+    private static int getReadTimeout() {
+        return ConfigUtils.getIntValue("ab.read.timeout", 5000);
+    }
+
+    public ABTestResponse requestABTestExperimentData(String projectId, String dataSourceId, String layerId, String distinctId) {
+        ABTestResponse outABTestResponse = new ABTestResponse();
+        DataOutputStream os = null;
+        BufferedReader br = null;
+        try {
+            String body = "accountId=" + URLEncoder.encode(projectId, Charset.forName("UTF-8").toString()) +
+                    "&datasourceId=" + URLEncoder.encode(dataSourceId, Charset.forName("UTF-8").toString()) +
+                    "&distinctId=" + URLEncoder.encode(distinctId, Charset.forName("UTF-8").toString()) +
+                    "&layerId=" + URLEncoder.encode(layerId, Charset.forName("UTF-8").toString());
+
+            HttpURLConnection httpConn = getConnection(apiHost());
+            httpConn.setRequestProperty("Content-Type", "application/x-www-form-urlencoded");
+            httpConn.setUseCaches(false);
+            httpConn.setRequestMethod("POST");
+            httpConn.setConnectTimeout(getConnectionTimeout());
+            httpConn.setReadTimeout(getReadTimeout());
+            httpConn.setRequestProperty("Content-Length", String.valueOf(body.getBytes().length));
+            httpConn.setDoOutput(true);
+
+            os = new DataOutputStream(httpConn.getOutputStream());
+            os.write(body.getBytes());
+            os.flush();
+
+            int responseCode = httpConn.getResponseCode();
+            if (responseCode >= 200 && responseCode < 300) {
+                br = new BufferedReader(new InputStreamReader(httpConn.getInputStream()));
+                String inputLine;
+                StringBuilder response = new StringBuilder();
+                while ((inputLine = br.readLine()) != null) {
+                    response.append(inputLine);
+                }
+                ABTestResponse abTestResponse = ABTestResponse.parseHttpJson(layerId, response.toString());
+                if (!abTestResponse.isSucceed()) {
+                    abTestResponse.setErrorMsg("ABExperiment data failed with: " + abTestResponse.getErrorMsg());
+                }
+                return abTestResponse;
+            } else {
+                outABTestResponse.setErrorMsg("ABTest request failed: " + responseCode);
+            }
+
+        } catch (Exception e) {
+            outABTestResponse.setErrorMsg("ABTest request failed: " + e.getLocalizedMessage());
+        } finally {
+            if (os != null) {
+                try {
+                    os.close();
+                } catch (IOException e) {
+                    outABTestResponse.setErrorMsg("ABTest request failed: " + e.getLocalizedMessage());
+                }
+                os = null;
+            }
+            if (br != null) {
+                try {
+                    br.close();
+                } catch (IOException e) {
+                    outABTestResponse.setErrorMsg("ABTest request failed: " + e.getLocalizedMessage());
+                }
+                br = null;
+            }
+        }
+        return outABTestResponse;
+    }
+
+    private String apiDomain() {
+        String apiHost = ConfigUtils.getStringValue("ab.api.host", "");
+        if (apiHost.endsWith("/")) {
+            return apiHost.substring(0, apiHost.length() - 1);
+        } else {
+            return apiHost;
+        }
+    }
+
+    private String apiHost() {
+        return apiDomain() + "/diversion/specified-layer-variables";
+    }
+
+    private HttpURLConnection getConnection(String url) throws IOException {
+        Proxy proxy = ProxyInfo.getProxy();
+
+        HttpURLConnection httpConn;
+        if (proxy == null) {
+            httpConn = (HttpURLConnection) new URL(url).openConnection();
+        } else {
+            httpConn = (HttpURLConnection) new URL(url).openConnection(proxy);
+        }
+
+        return httpConn;
+    }
+}

--- a/src/main/java/io/growing/sdk/java/ab/ABTestResponse.java
+++ b/src/main/java/io/growing/sdk/java/ab/ABTestResponse.java
@@ -1,0 +1,77 @@
+package io.growing.sdk.java.ab;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+
+class ABTestResponse {
+
+    private static final String LAYER_ID = "layerId";
+    private static final String LAYER_NAME = "layerName";
+    private static final String STRATEGY_ID = "strategyId";
+    private static final String STRATEGY_NAME = "strategyName";
+    private static final String EXPERIMENT_ID = "experimentId";
+    private static final String EXPERIMENT_NAME = "experimentName";
+    private static final String VARIABLES = "variables";
+
+    private int code = -1;
+    private String errorMsg;
+
+    ABExperiment abExperiment;
+
+    public int getCode() {
+        return code;
+    }
+
+    public String getErrorMsg() {
+        return errorMsg;
+    }
+
+    public static ABTestResponse parseHttpJson(String layerId, String json) {
+        final ABTestResponse response = new ABTestResponse();
+        try {
+            JSONObject jsonObject = new JSONObject(json);
+            int code = jsonObject.getInt("code");
+            response.code = code;
+            if (code == 0) {
+                long experimentId = jsonObject.optLong(EXPERIMENT_ID);
+                long strategyId = jsonObject.optLong(STRATEGY_ID);
+                JSONObject variables = jsonObject.optJSONObject(VARIABLES);
+                Map<String, String> variableMap = new HashMap<String, String>();
+                if (variables != null) {
+                    Iterator<String> keys = variables.keys();
+                    while (keys.hasNext()) {
+                        String key = keys.next();
+                        variableMap.put(key, variables.get(key).toString());
+                    }
+                }
+                response.abExperiment = new ABExperiment(layerId, strategyId, experimentId, variableMap);
+                String expLayerName = jsonObject.optString(LAYER_NAME);
+                String expName = jsonObject.optString(EXPERIMENT_NAME);
+                String expStrategyName = jsonObject.optString(STRATEGY_NAME);
+                response.abExperiment.setExperimentNames(expLayerName, expName, expStrategyName);
+            } else {
+                response.errorMsg = jsonObject.getString("errorMsg");
+            }
+        } catch (JSONException e) {
+            response.code = -1;
+            response.errorMsg = "parse error:Illegal ABExperiment";
+        }
+        return response;
+    }
+
+    public ABExperiment getABExperiment() {
+        return abExperiment;
+    }
+
+    public void setErrorMsg(String errorMsg) {
+        this.errorMsg = errorMsg;
+    }
+
+    boolean isSucceed() {
+        return code == 0;
+    }
+}

--- a/src/main/java/io/growing/sdk/java/sender/net/BaseNetProvider.java
+++ b/src/main/java/io/growing/sdk/java/sender/net/BaseNetProvider.java
@@ -1,0 +1,50 @@
+package io.growing.sdk.java.sender.net;
+
+import io.growing.sdk.java.utils.ConfigUtils;
+
+import java.net.Authenticator;
+import java.net.InetSocketAddress;
+import java.net.PasswordAuthentication;
+import java.net.Proxy;
+
+import static java.net.Proxy.Type.HTTP;
+
+public class BaseNetProvider {
+
+    protected static class ProxyInfo {
+        private static final Proxy proxy;
+
+        static {
+            proxy = setProxy();
+            setAuthenticator();
+        }
+
+        private static Proxy setProxy() {
+            String proxyHost = ConfigUtils.getStringValue("proxy.host", null);
+            Integer proxyPort = ConfigUtils.getIntValue("proxy.port", 80);
+
+            if (proxyHost == null || proxyHost.isEmpty()) {
+                return null;
+            }
+
+            return new Proxy(HTTP, new InetSocketAddress(proxyHost, proxyPort));
+        }
+
+        private static void setAuthenticator() {
+            final String proxyUser = ConfigUtils.getStringValue("proxy.user", null);
+            final String proxyPassword = ConfigUtils.getStringValue("proxy.password", null);
+
+            if (proxyUser != null && proxyPassword != null) {
+                Authenticator.setDefault(new Authenticator() {
+                    protected PasswordAuthentication getPasswordAuthentication() {
+                        return new PasswordAuthentication(proxyUser, proxyPassword.toCharArray());
+                    }
+                });
+            }
+        }
+
+        public static Proxy getProxy() {
+            return proxy;
+        }
+    }
+}

--- a/src/main/java/io/growing/sdk/java/sender/net/NetProviderAbstract.java
+++ b/src/main/java/io/growing/sdk/java/sender/net/NetProviderAbstract.java
@@ -5,21 +5,15 @@ import io.growing.sdk.java.logger.GioLogger;
 import io.growing.sdk.java.sender.RequestDto;
 import io.growing.sdk.java.utils.ConfigUtils;
 
-import java.net.Authenticator;
-import java.net.InetSocketAddress;
-import java.net.PasswordAuthentication;
-import java.net.Proxy;
 import java.util.HashMap;
 import java.util.Map;
-
-import static java.net.Proxy.Type.HTTP;
 
 /**
  * @author : tong.wang
  * @version : 1.0.0
  * @since : 2018-11-22 13:36
  */
-public abstract class NetProviderAbstract {
+public abstract class NetProviderAbstract extends BaseNetProvider {
     protected static final Map<String, String> HTTP_HEADERS = new HashMap<String, String>();
 
     protected static int getConnectionTimeout() {
@@ -38,43 +32,6 @@ public abstract class NetProviderAbstract {
     }
 
     protected abstract int sendPost(RequestDto requestDto);
-
-    protected static class ProxyInfo {
-        private static final Proxy proxy;
-
-        static {
-            proxy = setProxy();
-            setAuthenticator();
-        }
-
-        private static Proxy setProxy() {
-            String proxyHost = ConfigUtils.getStringValue("proxy.host", null);
-            Integer proxyPort = ConfigUtils.getIntValue("proxy.port", 80);
-
-            if (proxyHost == null || proxyHost.isEmpty()) {
-                return null;
-            }
-
-            return new Proxy(HTTP, new InetSocketAddress(proxyHost, proxyPort));
-        }
-
-        private static void setAuthenticator() {
-            final String proxyUser = ConfigUtils.getStringValue("proxy.user", null);
-            final String proxyPassword = ConfigUtils.getStringValue("proxy.password", null);
-
-            if (proxyUser != null && proxyPassword != null) {
-                Authenticator.setDefault(new Authenticator() {
-                    protected PasswordAuthentication getPasswordAuthentication() {
-                        return new PasswordAuthentication(proxyUser, proxyPassword.toCharArray());
-                    }
-                });
-            }
-        }
-
-        public static Proxy getProxy() {
-            return proxy;
-        }
-    }
 
     public abstract boolean connectedToGrowingAPIHost();
 }

--- a/src/main/java/io/growing/sdk/java/utils/MessageUtils.java
+++ b/src/main/java/io/growing/sdk/java/utils/MessageUtils.java
@@ -1,0 +1,26 @@
+package io.growing.sdk.java.utils;
+
+import io.growing.sdk.java.dto.GIOMessage;
+import io.growing.sdk.java.dto.GioCDPMessage;
+import io.growing.sdk.java.logger.GioLogger;
+
+public class MessageUtils {
+    public static boolean businessVerification(GIOMessage msg, String projectKey, String dataSourceId) {
+        if (StringUtils.nonBlank(projectKey)) {
+            msg.setProjectKey(projectKey);
+        } else {
+            GioLogger.error("projectKey cant be null or empty string");
+            return false;
+        }
+
+        if (msg instanceof GioCDPMessage) {
+            if (StringUtils.nonBlank(dataSourceId)) {
+                ((GioCDPMessage<?>) msg).setDataSourceId(dataSourceId);
+            } else {
+                GioLogger.error("cdp message datasourceId cant be null or empty string");
+                return false;
+            }
+        }
+        return true;
+    }
+}

--- a/src/main/resources/gio_default.properties
+++ b/src/main/resources/gio_default.properties
@@ -22,3 +22,12 @@ run.mode=production
 #connection.timeout=2000
 #http 连接读取时间
 #read.timeout=2000
+
+# 是否开启abtest
+ab.enabled=false
+# abtest的服务地址
+ab.api.host=https://ab.growingio.com
+# ab请求连接超时时间
+ab.connection.timeout=5000
+# ab请求读取时间
+ab.read.timeout=5000

--- a/src/test/java/io/growing/sdk/java/test/Case1MockHttpTest.java
+++ b/src/test/java/io/growing/sdk/java/test/Case1MockHttpTest.java
@@ -40,8 +40,7 @@ public class Case1MockHttpTest {
         properties.setProperty("api.host", "https://www.growingio.com");
         GrowingAPI.initConfig(properties);
         sender = new GrowingAPI.Builder().setDataSourceId(DATASOURCE_ID).setProjectKey(PROJECT_KEY).build();
-        factory = new StubStreamHandlerFactory();
-        URL.setURLStreamHandlerFactory(factory);
+        factory = StubStreamHandlerFactory.getInstance();
     }
 
     private static void setStaticField(Class clazz, String fieldName, Object value) {

--- a/src/test/java/io/growing/sdk/java/test/Case2ABTest.java
+++ b/src/test/java/io/growing/sdk/java/test/Case2ABTest.java
@@ -1,0 +1,211 @@
+package io.growing.sdk.java.test;
+
+import io.growing.collector.tunnel.protocol.EventV3Dto;
+import io.growing.collector.tunnel.protocol.EventV3List;
+import io.growing.sdk.java.GrowingAPI;
+import io.growing.sdk.java.ab.ABExperiment;
+import io.growing.sdk.java.ab.ABTestCallback;
+import io.growing.sdk.java.test.stub.StubStreamHandlerFactory;
+import org.junit.*;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.net.URL;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+
+@RunWith(JUnit4.class)
+public class Case2ABTest {
+
+    private static final String PROJECT_KEY = "91eaf9b283361032";
+    private static final String DATASOURCE_ID = "a390a68c7b25638c";
+    private static final String AB_DATASOURCE_ID = "ab90a68c7b25638c";
+
+    private static final String LAYER_ID = "JmjoD6pL";
+    private static final String DISTINCT_ID = "deviceId-187********";
+
+    private static GrowingAPI sender;
+    private static StubStreamHandlerFactory factory;
+
+    private volatile Exception mException;
+
+    private static void setStaticField(Class clazz, String fieldName, Object value) {
+        try {
+            Field field = clazz.getDeclaredField(fieldName);
+            field.setAccessible(true);
+            Field modifiersField = Field.class.getDeclaredField("modifiers");
+            modifiersField.setAccessible(true);
+            modifiersField.setInt(field, field.getModifiers() & ~Modifier.FINAL);
+            field.set(null, value);
+        } catch (Exception ignored) {
+        }
+    }
+
+    @Before
+    public void beforeTest() {
+        mException = null;
+    }
+
+    @After
+    public void afterTest() {
+        if (mException != null) {
+            Assert.fail(mException.getMessage());
+        }
+    }
+
+    @BeforeClass
+    public static void before() {
+        sender = new GrowingAPI.Builder().setDataSourceId(DATASOURCE_ID).setProjectKey(PROJECT_KEY).build();
+        factory = StubStreamHandlerFactory.getInstance();
+    }
+
+    @Test
+    public void getAbTestSuccess() throws InterruptedException {
+        final CountDownLatch countDownLatch = new CountDownLatch(2);
+        factory.setResponseHandler(new StubStreamHandlerFactory.ResponseHandler() {
+            @Override
+            public String getResponse(URL url) {
+                if (url.getPath().contains("/diversion")) {
+                    return "{\n" +
+                            "    \"code\": 0,\n" +
+                            "    \"errorMsg\": null,\n" +
+                            "    \"layerId\": 13,\n" +
+                            "    \"layerName\": \"首次访问引导\",\n" +
+                            "    \"experimentId\": 20,\n" +
+                            "    \"experimentName\": \"新用户首次访问引导弹窗pc\",\n" +
+                            "    \"strategyId\": 49,\n" +
+                            "    \"strategyName\": \"实验组1\",\n" +
+                            "    \"variables\": {\n" +
+                            "        \"isShow\": \"true\"\n" +
+                            "    }\n" +
+                            "}";
+                } else {
+                    return "OK";
+                }
+            }
+        });
+
+        factory.setStubHttpURLConnectionListener(new StubStreamHandlerFactory.StubHttpURLConnectionListener() {
+            @Override
+            public void onSend(URL url, byte[] msg) {
+                if (url.getPath().contains("/collect")) {
+                    try {
+                        EventV3List eventList = EventV3List.parseFrom(msg);
+                        EventV3Dto customEvent = eventList.getValues(0);
+                        Assert.assertEquals(AB_DATASOURCE_ID, customEvent.getDataSourceId());
+                        Assert.assertEquals(PROJECT_KEY, customEvent.getProjectKey());
+
+                        Assert.assertEquals("CUSTOM", customEvent.getEventType().name());
+                        Assert.assertEquals("$exp_hit", customEvent.getEventName());
+                        Assert.assertEquals(DISTINCT_ID, customEvent.getDeviceId());
+
+                        Map<String, String> attributes = customEvent.getAttributesMap();
+                        Assert.assertEquals(String.valueOf(20L), attributes.get("$exp_id"));
+                        Assert.assertEquals(String.valueOf(49L), attributes.get("$exp_strategy_id"));
+                        Assert.assertEquals(LAYER_ID, attributes.get("$exp_layer_id"));
+                        Assert.assertEquals("首次访问引导", attributes.get("$exp_layer_name"));
+                        Assert.assertEquals("新用户首次访问引导弹窗pc", attributes.get("$exp_name"));
+                        Assert.assertEquals("实验组1", attributes.get("$exp_strategy_name"));
+                    } catch (Exception e) {
+                        mException = e;
+                    }
+                    countDownLatch.countDown();
+                }
+            }
+        });
+
+        sender.getABTestSync(LAYER_ID, AB_DATASOURCE_ID, DISTINCT_ID, new ABTestCallback() {
+
+            @Override
+            public void onABExperimentReceived(ABExperiment experiment) {
+                try {
+                    Assert.assertEquals(LAYER_ID, experiment.getLayerId());
+                    Assert.assertEquals(20L, experiment.getExperimentId());
+                    Assert.assertEquals(49L, experiment.getStrategyId());
+                    Assert.assertEquals("新用户首次访问引导弹窗pc", experiment.getExpName());
+                    Assert.assertEquals("实验组1", experiment.getExpStrategyName());
+                    Assert.assertEquals("首次访问引导", experiment.getExpLayerName());
+                    Map<String, String> variables = experiment.getVariables();
+                    Assert.assertEquals(variables.get("isShow"), "true");
+                } catch (Exception e) {
+                    mException = e;
+                }
+                countDownLatch.countDown();
+            }
+
+            @Override
+            public void onABExperimentFailed(Exception error) {
+
+            }
+        });
+
+        countDownLatch.await();
+    }
+
+    @Test
+    public void getABTestFailed() throws InterruptedException {
+        final CountDownLatch countDownLatch = new CountDownLatch(1);
+        factory.setResponseHandler(new StubStreamHandlerFactory.ResponseHandler() {
+            @Override
+            public String getResponse(URL url) {
+                if (url.getPath().contains("/diversion")) {
+                    return "{\n" +
+                            "    \"code\": 999,\n" +
+                            "    \"errorMsg\": \"系统异常\",\n" +
+                            "    \"layerId\": null,\n" +
+                            "    \"layerName\": null,\n" +
+                            "    \"experimentId\": null,\n" +
+                            "    \"experimentName\": null,\n" +
+                            "    \"strategyId\": null,\n" +
+                            "    \"strategyName\": null,\n" +
+                            "    \"variables\": null\n" +
+                            "}";
+                } else {
+                    return "OK";
+                }
+            }
+        });
+
+        sender.getABTestSync(LAYER_ID, AB_DATASOURCE_ID, DISTINCT_ID, new ABTestCallback() {
+            @Override
+            public void onABExperimentReceived(ABExperiment experiment) {
+            }
+
+            @Override
+            public void onABExperimentFailed(Exception error) {
+                try {
+                    Assert.assertEquals(error.getLocalizedMessage(), "ABExperiment data failed with: 系统异常");
+                } catch (Exception e) {
+                    mException = e;
+                }
+                countDownLatch.countDown();
+            }
+        });
+
+        countDownLatch.await();
+    }
+
+    @Test
+    public void getABTestIllegal() {
+        try {
+            ABTestCallback callback = new ABTestCallback() {
+                @Override
+                public void onABExperimentReceived(ABExperiment experiment) {
+                }
+
+                @Override
+                public void onABExperimentFailed(Exception error) {
+                }
+            };
+            sender.getABTestSync(null, AB_DATASOURCE_ID, DISTINCT_ID, callback);
+            sender.getABTestSync(LAYER_ID, null, DISTINCT_ID, callback);
+            sender.getABTestSync(LAYER_ID, AB_DATASOURCE_ID, null, callback);
+            sender.getABTestSync(LAYER_ID, AB_DATASOURCE_ID, DISTINCT_ID, null);
+            sender.getABTestSync(null, null, null, null);
+        } catch (Exception e) {
+            Assert.fail(e.getLocalizedMessage());
+        }
+    }
+}

--- a/src/test/java/io/growing/sdk/java/test/Case3GrowingAPITest.java
+++ b/src/test/java/io/growing/sdk/java/test/Case3GrowingAPITest.java
@@ -26,7 +26,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
  * @since : 11/21/18 3:35 PM
  */
 @RunWith(JUnit4.class)
-public class Case2GrowingAPITest {
+public class Case3GrowingAPITest {
     private static GrowingAPI sender;
 
     @BeforeClass

--- a/src/test/java/io/growing/sdk/java/test/Case4EventMessageTest.java
+++ b/src/test/java/io/growing/sdk/java/test/Case4EventMessageTest.java
@@ -7,7 +7,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
 @RunWith(JUnit4.class)
-public class Case3EventMessageTest {
+public class Case4EventMessageTest {
 
     @Test
     public void checkCustomMessage() {

--- a/src/test/java/io/growing/sdk/java/test/Case5StringUtilsTest.java
+++ b/src/test/java/io/growing/sdk/java/test/Case5StringUtilsTest.java
@@ -10,7 +10,7 @@ import org.junit.Test;
 
 import java.util.HashMap;
 
-public class Case4StringUtilsTest {
+public class Case5StringUtilsTest {
 
     @Test
     public void checkMap2Str() {

--- a/src/test/java/io/growing/sdk/java/test/stub/StubStreamHandlerFactory.java
+++ b/src/test/java/io/growing/sdk/java/test/stub/StubStreamHandlerFactory.java
@@ -1,10 +1,33 @@
 package io.growing.sdk.java.test.stub;
 
+import io.growing.sdk.java.utils.StringUtils;
+
 import java.io.*;
 import java.net.*;
 
 public class StubStreamHandlerFactory implements URLStreamHandlerFactory {
     private StubHttpURLConnectionListener mStubHttpURLConnectionListener;
+    private ResponseHandler mResponseHandler;
+
+    public static StubStreamHandlerFactory getInstance() {
+        return SingleInstance.INSTANCE;
+    }
+
+    private static class SingleInstance {
+        private static final StubStreamHandlerFactory INSTANCE = new StubStreamHandlerFactory();
+    }
+
+    private StubStreamHandlerFactory() {
+        URL.setURLStreamHandlerFactory(this);
+    }
+
+    public interface ResponseHandler {
+        String getResponse(URL url);
+    }
+
+    public void setResponseHandler(ResponseHandler responseHandler) {
+        this.mResponseHandler = responseHandler;
+    }
 
     @Override
     public URLStreamHandler createURLStreamHandler(String protocol) {
@@ -58,6 +81,12 @@ public class StubStreamHandlerFactory implements URLStreamHandlerFactory {
 
         @Override
         public InputStream getInputStream() {
+            if (mResponseHandler != null) {
+                String response = mResponseHandler.getResponse(StubHttpURLConnection.this.getURL());
+                if (!StringUtils.isBlank(response)) {
+                    return new ByteArrayInputStream(response.getBytes());
+                }
+            }
             return new ByteArrayInputStream(new String("OK").getBytes());
         }
 

--- a/src/test/resources/gio.properties
+++ b/src/test/resources/gio.properties
@@ -1,6 +1,6 @@
-api.host=http://117.50.105.254:8080
-
 connection.timeout=5000
 read.timeout=5000
-run.mode=test
+run.mode=production
 logger.level=debug
+
+ab.enabled=true


### PR DESCRIPTION
## PR 内容
1. 支持ab实验接口
2. 新增如下配置， 默认值如下
```yaml
# 是否开启abtest
ab.enabled=false
# abtest的服务地址
ab.api.host=https://ab.growingio.com
# ab请求连接超时时间
ab.connection.timeout=5000
# ab请求读取时间
ab.read.timeout=5000
```

## 测试步骤
参考Case2ABTest

## 影响范围
不影响原有请求逻辑

## 是否属于重要变动？

- [ ] 是
- [x] 否

## 其他信息

无

